### PR TITLE
Fixed case of two different Runners having the same attributes.

### DIFF
--- a/db/merge_runners_helpers.rb
+++ b/db/merge_runners_helpers.rb
@@ -10,7 +10,8 @@ module MergeRunnersHelpers
     identifying_runner_attributes_group = [:first_name, :last_name, :nationality, :club_or_hometown, :sex, 'age']
     r = Runner.select(identifying_runner_attributes_select - [attr] + additional_attributes_select + ['array_agg(id) AS ids'])
             .group(identifying_runner_attributes_group - [attr] + additional_attributes_group).having('count(*) > 1')
-    r.map { |i| Runner.find(i['ids']) }
+    merge_candidates = r.map { |i| Runner.find(i['ids']) }
+    merge_candidates.select{|i| and i.first[attr] != i.second[attr]}
   end
 
   MALE_FIRST_NAMES = %w(Jannick)
@@ -20,7 +21,7 @@ module MergeRunnersHelpers
   POSSIBLY_WRONGLY_SPACED_ATTRIBUTES = [:first_name, :last_name, :club_or_hometown]
 
   def self.merge_duplicates
-    # Handle wrong sex, try to find correct correct sex using name list.
+    # Handle wrong sex, try to find correct sex using name list.
     find_runners_only_differing_in(:sex).each do |entries|
       if entries.size != 2
         raise 'More than two possibilities, dont know what to do!'


### PR DESCRIPTION
They should not be merged, because if seed adds such runners, it's
because there were two different runs at the same runDay associated with
the two runners - therefore they are not the same runner.
